### PR TITLE
(maint) replace spdy with http2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class webhook_proxy (
 
   nginx::resource::server { 'webhook':
     server_name          => [$canonical_fqdn],
-    spdy                 => 'on',
+    http2                => 'on',
     listen_port          => 443,
     ssl                  => true,
     ssl_cert             => "${ssl::cert_dir}/${ssl_name}_combined.crt",


### PR DESCRIPTION
spdy was superseded by http2 in nginx 1.9.5 and as of 1.20 is not
handled as a directive at all.