### PR TITLE
(DIO-2232) Removes endpoint trailing /

### DIFF
--- a/manifests/endpoint.pp
+++ b/manifests/endpoint.pp
@@ -16,7 +16,7 @@
 #   webhook_proxy::endpoint { 'https://pe-prod.internal.example.com:8170/code-manager/v1/webhook': }
 #
 define webhook_proxy::endpoint (
-  Pattern[/^\//] $path = $name.regsubst('^https?://', '/').regsubst('/*$', '/'),
+  Pattern[/^\//] $path = $name.regsubst('^https?://', '/'),
   Pattern[/^https?:\/\/\w.+\//] $target = $name,
 ) {
   include nginx

--- a/spec/classes/webhook_proxy_spec.rb
+++ b/spec/classes/webhook_proxy_spec.rb
@@ -59,10 +59,10 @@ describe 'webhook_proxy' do
 
         it 'two endpoint resources are crated' do
           is_expected.to contain_webhook_proxy__endpoint('https://pe-prod.internal.example.com:8170/code-manager/v1/webhook')
-          is_expected.to contain_nginx__resource__location('webhook = /pe-prod.internal.example.com:8170/code-manager/v1/webhook/')
+          is_expected.to contain_nginx__resource__location('webhook = /pe-prod.internal.example.com:8170/code-manager/v1/webhook')
 
           is_expected.to contain_webhook_proxy__endpoint('http://cd4pe-prod.internal.example.com:8000/github/push')
-          is_expected.to contain_nginx__resource__location('webhook = /cd4pe-prod.internal.example.com:8000/github/push/')
+          is_expected.to contain_nginx__resource__location('webhook = /cd4pe-prod.internal.example.com:8000/github/push')
         end
       end
 

--- a/spec/defines/endpoint_spec.rb
+++ b/spec/defines/endpoint_spec.rb
@@ -12,8 +12,8 @@ describe 'webhook_proxy::endpoint' do
 
         it { is_expected.to compile }
         it {
-          is_expected.to contain_nginx__resource__location('webhook = /pe-prod.internal.example.com:8170/code-manager/v1/webhook/')
-            .with_location('= /pe-prod.internal.example.com:8170/code-manager/v1/webhook/')
+          is_expected.to contain_nginx__resource__location('webhook = /pe-prod.internal.example.com:8170/code-manager/v1/webhook')
+            .with_location('= /pe-prod.internal.example.com:8170/code-manager/v1/webhook')
         }
       end
 


### PR DESCRIPTION
This modifies the endpoint defined type so that the a trailing `/` is **not** added to the resource location string.  I don't know why it originally did this but it results in having to configure webhooks with the added `/` in order to proxy correctly.  This meant that you would need to enter a webhook in github that looked like this:
```
https://webhookproxy.example.com/my-server.net:123/github/push/?apiToken=<>
```
rather than the more intuitive:
```
https://webhookproxy.example.com/my-server.net:123/github/push?apiToken=<>
```